### PR TITLE
Revert "Relax pymongo pin to use CVE fixed version"

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,7 +56,7 @@ outputs:
         - pyarrow {{ arrow }}
         - pydot >=1.2.0,<2
         - python-dateutil >=2.8.0,<3
-        - pymongo >=3.8.0,<5.0.0
+        - pymongo >=3.8.0,<4.0.0
         - pytz >=2018.3
         - regex {{ regex }}
         - requests {{ requests }}


### PR DESCRIPTION
Reverts open-ce/apache-beam-feedstock#14